### PR TITLE
Fix ansible-lint trailing spaces notices

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
  - name: restart docker
-   service: name=docker state=restarted 
+   service: name=docker state=restarted

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: Julien DAUPHANT
-  description: Ansible role to install Docker 
+  description: Ansible role to install Docker
   license: ISC
   min_ansible_version: 1.8.2
   platforms:

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -2,8 +2,11 @@
 - name: Ensure docker apt key is present
   apt_key: url=https://get.docker.io/gpg state=present
 
+- name: Ensure apt-transport-https installedq
+  apt: name=apt-transport-https state=present
+
 - name: Ensure docker repository is present
-  apt_repository: repo='deb http://get.docker.io/ubuntu docker main' state=present
+  apt_repository: repo='deb https://get.docker.io/ubuntu docker main' state=present
 
 - name: Ensure docker packages are present
   apt: name=lxc-docker state=present

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure docker apt key is present
-  apt_key: url=https://get.docker.io/gpg state=present 
+  apt_key: url=https://get.docker.io/gpg state=present
 
 - name: Ensure docker repository is present
   apt_repository: repo='deb http://get.docker.io/ubuntu docker main' state=present


### PR DESCRIPTION
## Before:

$ ansible-lint test.yml 

```
[ANSIBLE0002] Trailing whitespace
/home/popstas/projects/ansible/ansible-role-docker/handlers/main.yml:3
   service: name=docker state=restarted 

[ANSIBLE0002] Trailing whitespace
/home/popstas/projects/ansible/ansible-role-docker/meta/main.yml:4
  description: Ansible role to install Docker 

[ANSIBLE0002] Trailing whitespace
/home/popstas/projects/ansible/ansible-role-docker/tasks/Debian.yml:3
  apt_key: url=https://get.docker.io/gpg state=present 
```

$
## After

$ ansible-lint test.yml
$
